### PR TITLE
fix smaller than max size offsets

### DIFF
--- a/src/main/lib/generator/patchInfo.ts
+++ b/src/main/lib/generator/patchInfo.ts
@@ -132,6 +132,7 @@ export class PatchInfo {
               romInfo.freeSpace(new ROMOffset(location.offset.absoluteOffset + farcall.size()), location.maxSize - farcall.size())
             }
           } else {
+            romOffsets.push(location.offset)
             romInfo.freeSpace(new ROMOffset(location.offset.absoluteOffset + dataFormat.size()), location.maxSize - dataFormat.size())
           }
         } else {


### PR DESCRIPTION
- Fixed an issue with processing a patch spec with a change with a location that has a max size and the resolved change size is smaller than the max size.