### PR TITLE
Default file name

### DIFF
--- a/src/main/lib/generator/generator.ts
+++ b/src/main/lib/generator/generator.ts
@@ -80,7 +80,7 @@ export const generateROM = async (params: {
     title: "Save Generated ROM to:",
     buttonLabel: "Generate",
     fileType: "gbc" as const,
-    defaultFilePath: defaultFileName ?? generatorResult.seed,
+    defaultFilePath: defaultFileName ?? customSeed ?? generatorResult.checkValue,
   }
   
   let filePath: string | undefined
@@ -114,11 +114,7 @@ const generateROMData = (params: {
   settings: Settings,
   playerOptions: PlayerOptions,
   generateLog: boolean
-}): {
-  seed: string
-  data: Buffer
-  log: string | undefined
-} => {
+}) => {
   const {
     data,
     customSeed,
@@ -172,6 +168,7 @@ const generateROMData = (params: {
     seed: seed,
     data: data,
     log: log,
+    checkValue: checkValue,
   }
 }
 


### PR DESCRIPTION
- Use the shorter check value as the default file name when generating a rom without a custom seed.