### PR TITLE
Trainer name fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-crystal-randomizer",
   "productName": "Pokemon Crystal Randomizer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Generate and apply patches for Pokémon Crystal Version",
   "author": "David Bagwell",
   "license": "MIT",

--- a/src/shared/appData/defaultPlayerOptionsViewModel.ts
+++ b/src/shared/appData/defaultPlayerOptionsViewModel.ts
@@ -17,7 +17,6 @@ export const defaultPlayerOptionsViewModel = () => {
       menuAccountOption(),
       printerToneOption(),
       frameTypeOption(),
-      trainerClassNamesOption(),
       trainerNamesOption(),
     ],
   }
@@ -238,51 +237,11 @@ const frameTypeOption = () => {
   })
 }
 
-const trainerClassNamesOption = () => {
-  return createConfigurableToggleViewModel({
-    id: "CHANGE_TRAINER_CLASS_NAMES" as const,
-    name: "Change Trainer Class Names",
-    description: "Changes the names of the trainer classes.\n"
-      + "Note: The combined character count of a trainer's name and class name can never exceed 17 (16 for certain trainers).",
-    viewModels: [
-      createSingleSelectorViewModel({
-        id: "METHOD" as const,
-        selectedOptionId: "SHUFFLED",
-        options: [
-          createSimpleSelectorOption({
-            id: "SHUFFLED" as const,
-            name: "Shuffled",
-            description: "Shuffles the vanilla names of the trainers classes around.",
-          }),
-          createConfigurableSelectorOption({
-            id: "CUSTOM_LIST" as const,
-            name: "Custom List",
-            description: "Switches each trainer class name for a random one from the supplied list.\n"
-              + "Each name should be on its own line and names in the list should be no longer than 13 'in-game characters' or they will be truncated. "
-              + "The list must also contain at least 1 name that is no larger than 7 'character tokens' long. "
-              + "(For best results it is recommended to have a variety of names ranging from 4-13 characters).",
-            viewModels: [
-              createMultilineTextInputViewModel({
-                id: "ClASS_NAMES" as const,
-              }),
-            ] as const,
-          }),
-        ] as const,
-      }),
-      createSimpleToggleViewModel({
-        id: "CREATE_LOG" as const,
-        name: "Create Log File of Changed Names",
-        description: "Creates a log file whenever a ROM is generated that shows what each trainer name has become.",
-      }),
-    ] as const,
-  })
-}
-
 const trainerNamesOption = () => {
   return createConfigurableToggleViewModel({
     id: "CHANGE_TRAINER_NAMES" as const,
     name: "Change Trainer Names",
-    description: "Changes the names of the trainers that can be fought throughout the game.\n"
+    description: "Changes the names and class names of the trainers that can be fought throughout the game.\n"
       + "Note: The combined character count of a trainer's name and class name can never exceed 17 (16 for certain trainers).",
     viewModels: [
       createSingleSelectorViewModel({
@@ -292,16 +251,25 @@ const trainerNamesOption = () => {
           createSimpleSelectorOption({
             id: "SHUFFLED" as const,
             name: "Shuffled",
-            description: "Shuffles the vanilla names of the trainers around. (The names of trainers in the 'TWINS' trainer class will only be shuffled amongs the other 'TWINS'.)",
+            description: "Class names are shuffled amongst each other and trainer names are shuffled amongst each other (the names of trainers in the vanilla 'TWINS' trainer class are only shuffled amongst each other).",
           }),
           createConfigurableSelectorOption({
             id: "CUSTOM_LIST" as const,
             name: "Custom List",
             description: "Switches each trainer name for a random one from the supplied list.\n"
-              + "Each name should be on its own line and names in the list should be no longer than 10 'in-game characters' or they will be truncated. "
-              + "(The lengths of trainer's names may also be limited by the length of their class name).\n"
+              + "Each name in the lists should be on its own line.\n"
+              + "Class names should be no longer than 13 'in-game characters' or they will be truncated. "
+              + "The list of class names must also contain at least 1 name that is no larger than 7 'character tokens' long. "
+              + "If the list of class names is empty, they won't be changed. "
+              + "(For best results it is recommended to have a variety of class names ranging from 4-13 characters).\n"
+              + "Each trainer name should be no longer than 10 'in-game characters' or they will be truncated. "
+              + "(The lengths of trainer's names may also be limited by the length of their assigned class name).\n"
               + "There is a separate list for the names of trainers in the 'TWINS' trainer class since thematically they should be 2 separate names, but are treated as only 1 name in the game.",
             viewModels: [
+              createMultilineTextInputViewModel({
+                id: "ClASS_NAMES" as const,
+                name: "Class Names",
+              }),
               createMultilineTextInputViewModel({
                 id: "TRAINER_NAMES" as const,
                 name: "Single Trainer Names",

--- a/src/worker/gameDataProcessors/trainerNames.ts
+++ b/src/worker/gameDataProcessors/trainerNames.ts
@@ -1,82 +1,8 @@
 import type { PlayerOptions } from "@shared/appData/settingsFromViewModel"
 import type { PlayerSpecificGameData } from "@shared/types/gameData/gameData"
+import type { Trainer } from "@shared/types/gameData/trainer"
 import { bytesFromTextData, inGameStringLength, truncateToInGameStringLength } from "@shared/utils/textConverters"
 import type { Random } from "@worker/random"
-
-export const updateTrainerClassNames = (
-  playerOptions: PlayerOptions,
-  gameData: PlayerSpecificGameData,
-  random: Random,
-) => {
-  if (playerOptions.CHANGE_TRAINER_CLASS_NAMES) {
-    const method = playerOptions.CHANGE_TRAINER_CLASS_NAMES.SETTINGS.METHOD
-    const trainerClasses = Object.values(gameData.trainerClasses)
-    
-    switch (method.VALUE) {
-    case "SHUFFLED": {
-      const classNames = trainerClasses.map((trainerClass) => {
-        return trainerClass.name
-      })
-      
-      trainerClasses.forEach((trainerClass) => {
-        trainerClass.name = random.element({
-          array: classNames,
-          remove: true,
-        })
-      })
-      
-      break
-    }
-    case "CUSTOM_LIST": {
-      let classNames = method.SETTINGS.CUSTOM_LIST.ClASS_NAMES?.split("\n").map((name) => {
-        return truncateToInGameStringLength(name, 13)
-      }).filter((name) => {
-        return name.length > 0
-      }) ?? []
-      
-      const numberOfCustomNames = classNames.length
-      
-      if (numberOfCustomNames < 1) {
-        classNames = ["TRAINER"]
-      }
-      
-      classNames.sort((a, b) => {
-        return bytesFromTextData(a).length - bytesFromTextData(b).length
-      })
-      
-      if (classNames[0].length > 7) {
-        classNames = ["TRAINER"]
-      }
-      
-      let availableBytes = 502
-      
-      let classNameIndex = 0
-      const trainerClassIndices = trainerClasses.map((_, index) => { return index })
-      while (trainerClassIndices.length > 0) {
-        const trainerClassIndex = random.element({
-          array: trainerClassIndices,
-          remove: true,
-        })
-        
-        trainerClasses[trainerClassIndex].name = classNames[classNameIndex]
-        availableBytes -= trainerClasses[trainerClassIndex].name.length
-        
-        classNameIndex++
-        
-        if (classNameIndex === classNames.length || classNames[0].length * (trainerClassIndices.length - 1) > availableBytes - classNames[classNameIndex].length) {
-          classNameIndex = 0
-        }
-      }
-      
-      break
-    }
-    default: {
-      const unhandledCase: never = method.VALUE
-      throw new Error(`Unhandled case: ${unhandledCase}`)
-    }
-    }
-  }
-}
 
 export const updateTrainerNames = (
   playerOptions: PlayerOptions,
@@ -85,45 +11,56 @@ export const updateTrainerNames = (
 ) => {
   if (playerOptions.CHANGE_TRAINER_NAMES.VALUE) {
     const method = playerOptions.CHANGE_TRAINER_NAMES.SETTINGS.METHOD
+    const trainerClasses = Object.values(gameData.trainerClasses)
+    
     switch (method.VALUE) {
     case "SHUFFLED": {
+      // Shuffle class names
+      
+      const availableClassNames = trainerClasses.map((trainerClass) => {
+        return trainerClass.name
+      })
+      
+      trainerClasses.forEach((trainerClass) => {
+        trainerClass.name = random.element({
+          array: availableClassNames,
+          remove: true,
+        })
+      })
+      
+      // Shuffle single trainer names
+      
+      const maxNameLength = (trainer: Trainer) => {
+        const className = gameData.trainerClasses[trainer.classId].name
+        const combinedMaxLength = trainer.isContestTrainer ?? false ? 16 : 17
+        return combinedMaxLength - inGameStringLength(className)
+      }
+      
       const singleTrainers = gameData.trainers.filter((trainer) => {
         return trainer.classId !== "TWINS" && trainer.name !== "???"
+      }).toSorted((a, b) => {
+        return maxNameLength(a) - maxNameLength(b)
       })
       
       const singleTrainerNames = singleTrainers.map((trainer) => {
         return trainer.name
       })
       
-      singleTrainers.filter((trainer) => {
-        return trainer.isContestTrainer ?? false
-      }).forEach((trainer) => {
-        const className = gameData.trainerClasses[trainer.classId].name
+      singleTrainers.forEach((trainer) => {
         const validNameIndices = singleTrainerNames.reduce((result, name, index) => {
-          if (inGameStringLength(className) + inGameStringLength(name) < 17) {
+          if (inGameStringLength(name) <= maxNameLength(trainer)) {
             return [...result, index]
           } else {
             return result
           }
         }, [] as number[])
         
-        const index = random.element({
-          array: validNameIndices,
-          remove: true,
-        })
-        
+        const index = random.element({ array: validNameIndices })
         trainer.name = singleTrainerNames[index]
         singleTrainerNames.splice(index, 1)
       })
       
-      singleTrainers.filter((trainer) => {
-        return !(trainer.isContestTrainer ?? false)
-      }).forEach((trainer) => {
-        trainer.name = random.element({
-          array: singleTrainerNames,
-          remove: true,
-        })
-      })
+      // Shuffle twin trainer names
       
       const twinTrainers = gameData.trainers.filter((trainer) => {
         return trainer.classId === "TWINS"
@@ -143,6 +80,46 @@ export const updateTrainerNames = (
       break
     }
     case "CUSTOM_LIST": {
+      // Randomize class names
+      
+      const availableClassNames = method.SETTINGS.CUSTOM_LIST.ClASS_NAMES?.split("\n").map((name) => {
+        return truncateToInGameStringLength(name, 13)
+      }).filter((name) => {
+        return name.length > 0
+      }) ?? []
+      
+      if (availableClassNames.length > 1) {
+        availableClassNames.sort((a, b) => {
+          return bytesFromTextData(a).length - bytesFromTextData(b).length
+        })
+      
+        if (bytesFromTextData(availableClassNames[0]).length > 7) {
+          availableClassNames.unshift("TRAINER")
+        }
+      
+        let availableBytes = 502
+      
+        let classNameIndex = 0
+        const trainerClassIndices = trainerClasses.map((_, index) => { return index })
+        while (trainerClassIndices.length > 0) {
+          const trainerClassIndex = random.element({
+            array: trainerClassIndices,
+            remove: true,
+          })
+        
+          trainerClasses[trainerClassIndex].name = availableClassNames[classNameIndex]
+          availableBytes -= trainerClasses[trainerClassIndex].name.length
+        
+          classNameIndex++
+        
+          if (classNameIndex === availableClassNames.length || availableClassNames[0].length * (trainerClassIndices.length - 1) > availableBytes - availableClassNames[classNameIndex].length) {
+            classNameIndex = 0
+          }
+        }
+      }
+      
+      // Randomize Trainer Names
+      
       const singleTrainerNames = method.SETTINGS.CUSTOM_LIST.TRAINER_NAMES?.split("\n").map((name) => {
         return truncateToInGameStringLength(name, 10)
       }).filter((name) => {

--- a/src/worker/generator.ts
+++ b/src/worker/generator.ts
@@ -49,7 +49,7 @@ import { updatePrices } from "@worker/gameDataProcessors/prices"
 import { updateStarterItems, updateStarters } from "@worker/gameDataProcessors/starters"
 import { updateTeachableMoves } from "@worker/gameDataProcessors/teachableMoves"
 import { updateTrades } from "@worker/gameDataProcessors/trades"
-import { updateTrainerClassNames, updateTrainerNames } from "@worker/gameDataProcessors/trainerNames"
+import { updateTrainerNames } from "@worker/gameDataProcessors/trainerNames"
 import { updateTrainers } from "@worker/gameDataProcessors/trainers"
 import { updateUnownSets } from "@worker/gameDataProcessors/unownSets"
 import { generatorLog, playerSpecificLog } from "@worker/log"
@@ -137,8 +137,7 @@ export const applyPlayerOptions = (params: ApplyPlayerOptionsParams) => {
     trainers: JSON.parse(JSON.stringify(trainers)) as typeof trainers,
   }
   
-  updateTrainerClassNames(playerOptions, gameData, random)
-  updateTrainerNames(playerOptions, gameData, random) // Must be after updateTrainerClassNames
+  updateTrainerNames(playerOptions, gameData, random)
   
   const hunks = createPlayerOptionsPatches({
     settings: settings,
@@ -149,10 +148,7 @@ export const applyPlayerOptions = (params: ApplyPlayerOptionsParams) => {
   
   applyDataHunks(rom, hunks)
   
-  const shouldLogTrainerClassNames = playerOptions.CHANGE_TRAINER_CLASS_NAMES.VALUE && playerOptions.CHANGE_TRAINER_CLASS_NAMES.SETTINGS.CREATE_LOG
-  const shouldLogTrainerNames = playerOptions.CHANGE_TRAINER_NAMES.VALUE && playerOptions.CHANGE_TRAINER_NAMES.SETTINGS.CREATE_LOG
-  
-  if (shouldLogTrainerClassNames || shouldLogTrainerNames) {
+  if (playerOptions.CHANGE_TRAINER_NAMES.VALUE && playerOptions.CHANGE_TRAINER_NAMES.SETTINGS.CREATE_LOG) {
     return playerSpecificLog(gameData)
   } else {
     return undefined
@@ -2481,9 +2477,11 @@ const createPlayerOptionsPatches = (params: {
     { offset: romOffsetFromBankAddress(5, 0x4F80), values: [printToneValue(playerOptions.PRINT_TONE)] },
   ])
   
-  // Class Names
+  // Trainer Names
   
-  if (playerOptions.CHANGE_TRAINER_CLASS_NAMES.VALUE) {
+  if (playerOptions.CHANGE_TRAINER_NAMES.VALUE) {
+    // Class names
+    
     patchHunks.push({
       offset: romOffsetFromBankAddress(11, 0x41EF),
       values: Object.values(gameData.trainerClasses).flatMap((trainerClass) => {
@@ -2493,11 +2491,9 @@ const createPlayerOptionsPatches = (params: {
         ]
       }),
     })
-  }
-  
-  // Trainer Names
-  
-  if (playerOptions.CHANGE_TRAINER_NAMES.VALUE) {
+    
+    // Trainer names
+    
     const trainerDataOffset = romOffsetFromBankAddress(14, 0x5A1F)
     let trainerIndex = 0
     let readOffset = trainerDataOffset

--- a/src/worker/log.ts
+++ b/src/worker/log.ts
@@ -397,7 +397,7 @@ export const generatorLog = (params: {
           return !(trainer.unused ?? false) && trainer.classId === classId
         })
       }).toSorted((a, b) => {
-        const classResult = a.classId.localeCompare(b.classId)
+        const classResult = trainerClassesMap[a.classId].name.localeCompare(trainerClassesMap[b.classId].name)
         const nameResult = a.name.localeCompare(b.name)
         if (classResult === 0) {
           if (nameResult === 0) {
@@ -699,7 +699,7 @@ export const playerSpecificLog = (gameData: PlayerSpecificGameData) => {
         }).filter((pair) => {
           return !(pair[0].unused ?? false) && (isNullish(pair[0].party) || pair[0].party === 1) && pair[0].name !== "???"
         }).toSorted((a, b) => {
-          const classResult = a[0].classId.localeCompare(b[0].classId)
+          const classResult = trainerClassesMap[a[0].classId].name.localeCompare(trainerClassesMap[b[0].classId].name)
           if (classResult === 0) {
             return a[0].name.localeCompare(b[0].name)
           } else {
@@ -740,6 +740,8 @@ const logTable = (params: {
           return movesMap[value].name.toUpperCase()
         } else {
           return value
+            .replaceAll("<PKMN>", "PKMN")
+            .replaceAll("<POKé>", "POKé")
         }
       })
     })


### PR DESCRIPTION
Changes to the player options for changing the class/trainer names to fix some issues where the combined length of some trainers' class name and name could be too long when using certain combinations of settings.