### PR TITLE
Random names improvements

### DIFF
--- a/src/main/lib/ipc/mainAPI.ts
+++ b/src/main/lib/ipc/mainAPI.ts
@@ -3,9 +3,10 @@ import { rendererAPIResponseListeners } from "@lib/ipc/rendererAPIUtils"
 import { getPreference, setPreference } from "@lib/userData/preferences"
 import { getPlayerOptions, getSavedSettings, getSavedSettingsNames, getSettingsForPresetId, removeSavedSettings, saveSettings, setPlayerOptions, setPreviousSettings } from "@lib/userData/userData"
 import { getVanillaROM } from "@lib/userData/vanillaROM"
-import type { PlayerOptions, Settings } from "@shared/appData/settingsFromViewModel"
+import { type NameListId, nameListIds, nameLists } from "@shared/appData/nameListIds"
+import { type PlayerOptions, type Settings } from "@shared/appData/settingsFromViewModel"
 import type { MainAPIInterface } from "@shared/types/ipc/mainAPIInterface"
-import { isNullish } from "@shared/utils"
+import { isNotNullish, isNullish, numberFrom } from "@shared/utils"
 import { app, dialog } from "electron"
 import { type ElectronMainApi, RelayedError } from "electron-affinity/main"
 import fs from "fs"
@@ -159,6 +160,103 @@ export class MainAPI implements ElectronMainApi<MainAPI>, MainAPIInterface {
       
       return {
         message: "Settings exported!",
+      }
+    } catch (error: any) {
+      console.log(error.stack)
+      throw new RelayedError(`${error}`)
+    }
+  }
+  
+  readonly importCustomNames = async (): Promise<APIResponse<Partial<Record<NameListId, string>>>> => {
+    try {
+      const filePath = dialog.showOpenDialogSync({
+        title: "Import Custom Names from:",
+        filters: [
+          {
+            name: "text",
+            extensions: [
+              "txt",
+              "rncn",
+            ],
+          },
+        ],
+        buttonLabel: "Import",
+
+      })
+        
+      if (isNullish(filePath)) {
+        throw new Error("No file selected.")
+      }
+      
+      const fileData = fs.readFileSync(filePath[0])
+      const importedLists: Partial<Record<NameListId, string>> = {}
+      
+      if (isNotNullish(filePath[0].match(/.rncn$/))) {
+        let currentIndex = 1
+        nameLists.toSorted((a, b) => {
+          return a.rncnSortOrder - b.rncnSortOrder
+        }).forEach((list) => {
+          if (currentIndex >= fileData.length) {
+            return
+          }
+          
+          const size = numberFrom([...fileData.subarray(currentIndex, currentIndex + 4)], true)
+          currentIndex += 4
+          const listData = fileData.subarray(currentIndex, currentIndex + size)
+          currentIndex += size
+          
+          importedLists[list.id] = listData.toString().replaceAll("\r\n", "\n")
+        })
+      } else {
+        const fileText = fileData.toString().replaceAll(/\n\n+/g, "\n")
+        nameListIds.forEach((id) => {
+          importedLists[id] = fileText.match(`##### ${id} #####\n([\\s\\S]*?)(\n?#####|$)`)?.[1]
+        })
+      }
+      
+      return {
+        result: importedLists,
+      }
+    } catch (error: any) {
+      console.log(error.stack)
+      throw new RelayedError(`${error}`)
+    }
+  }
+  
+  readonly exportCustomNames = async (lists: Partial<Record<NameListId, string>>): Promise<VoidAPIResponse> => {
+    try {
+      const filePath = dialog.showSaveDialogSync({
+        title: "Save Exported Names to:",
+        defaultPath: "names.txt",
+        filters: [
+          {
+            name: "text",
+            extensions: [
+              "txt",
+            ],
+          },
+        ],
+        buttonLabel: "Export",
+        properties: [
+          "showOverwriteConfirmation",
+        ],
+      })
+        
+      if (isNullish(filePath)) {
+        throw new Error("A save location must be specified.")
+      }
+      
+      const text = Object.entries(lists).flatMap(([id, names]) => {
+        return [
+          `##### ${id} #####`,
+          names ?? "",
+        ]
+      }).join("\n\n")
+      
+      fs.writeFileSync(filePath, text)
+      
+      return {
+        message: "Names exported!",
       }
     } catch (error: any) {
       console.log(error.stack)

--- a/src/main/lib/ipc/mainAPI.ts
+++ b/src/main/lib/ipc/mainAPI.ts
@@ -57,7 +57,7 @@ export class MainAPI implements ElectronMainApi<MainAPI>, MainAPIInterface {
       }
     } catch (error: any) {
       console.log(error.stack)
-      if (error.message.includes("EEXIST")) {
+      if (error.message.includes("EEXIST") as boolean) {
         throw new RelayedError(`Preset name '${name}' already exists.`)
       } else {
         throw new RelayedError(`${error}`)

--- a/src/renderer/components/AppView.svelte
+++ b/src/renderer/components/AppView.svelte
@@ -313,8 +313,13 @@
     applyNewSettings(lastSelectedSettings)
   })
   
+  let savePlayerOptionsDebounceTimeout: NodeJS.Timeout
   const onPlayerOptionsUpdated = (updatedPlayerOptons: PlayerOptions) => {
     playerOptions = updatedPlayerOptons
+    clearTimeout(savePlayerOptionsDebounceTimeout)
+    savePlayerOptionsDebounceTimeout = setTimeout(() => {
+      savePlayerOptions()
+    }, 3000)
   }
   
   const applyNewSettings = (settings: unknown | undefined) => {
@@ -424,20 +429,18 @@
   }
   
   const playerOptionsButtonClicked = () => {
-    const savePlayerOptions = async () => {
-      showProgressIndicator()
-      await window.mainAPI.savePlayerOptions($state.snapshot(playerOptions))
-      hideProgressIndicator()
-    }
-    
     showDialog({
       title: "Player Options",
       message: "The following options are meant to be customized on a per player basis and are not included when exporting settings or sharing patches with others.",
       extraContent: playerOptionsView,
       submitButtonLabel: "Done",
-      onSubmit: savePlayerOptions,
-      onCancel: savePlayerOptions,
     })
+  }
+  
+  const savePlayerOptions = async () => {
+    showProgressIndicator()
+    await window.mainAPI.savePlayerOptions($state.snapshot(playerOptions))
+    hideProgressIndicator()
   }
   
   const createNewPresetButtonClicked = () => {

--- a/src/renderer/components/AppView.svelte
+++ b/src/renderer/components/AppView.svelte
@@ -450,7 +450,7 @@
         title: "Preset Name",
         type: "text",
         validator: (text) => {
-          const nameExists = presetOptions.find((option) => {
+          const nameExists = presetOptions.some((option) => {
             return option.id === text
           })
           

--- a/src/renderer/components/PlayerOptionsView.svelte
+++ b/src/renderer/components/PlayerOptionsView.svelte
@@ -67,4 +67,40 @@
       hasMounted = true
     }
   })
+  
+  handleButton = async (id: ButtonId) => {
+    switch (id) {
+    case "IMPORT_CUSTOM_NAMES": {
+      const namesLists = (await window.mainAPI.importCustomNames()).result
+      playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.CLASS_NAMES = namesLists.CLASS_NAMES
+      playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.TWINS_CLASS_NAMES = namesLists.TWINS_CLASS_NAMES
+      playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.TRAINER_NAMES = namesLists.TRAINER_NAMES
+      playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.TWINS_TRAINER_NAMES = namesLists.TWINS_TRAINER_NAMES
+      playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.POKEMON_NICKNAMES = namesLists.POKEMON_NICKNAMES
+      applyPlayerOptionsToViewModel(playerOptions, playerOptionsViewModel, [])
+      
+      break
+    }
+    case "EXPORT_CUSTOM_NAMES": {
+      window.mainAPI.exportCustomNames({
+        CLASS_NAMES: playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.CLASS_NAMES,
+        TWINS_CLASS_NAMES: playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.TWINS_CLASS_NAMES,
+        TRAINER_NAMES: playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.TRAINER_NAMES,
+        TWINS_TRAINER_NAMES: playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.TWINS_TRAINER_NAMES,
+        POKEMON_NICKNAMES: playerOptions.CHANGE_NAMES.SETTINGS.METHOD.SETTINGS.CUSTOM_LIST.POKEMON_NICKNAMES,
+      })
+      break
+    }
+    }
+  }
+</script>
+
+<script
+  lang="ts"
+  module
+>
+  import type { ButtonId } from "@shared/appData/buttonIds"
+  
+  export let handleButton: (id: ButtonId) => void
+
 </script>

--- a/src/renderer/components/PlayerOptionsWindow.svelte
+++ b/src/renderer/components/PlayerOptionsWindow.svelte
@@ -1,6 +1,6 @@
 <DialogContent
   extraContent={playerOptionsView}
-  message={"Customize your individual game experience.\nThe selected options will be used as the default options for all patches going forward, but can be changed from within the main randomizer application at any time.\nCertain options may not be used depending on the settings used to generate the patch."}
+  message="Customize your individual game experience.\nThe selected options will be used as the default options for all patches going forward, but can be changed from within the main randomizer application at any time.\nCertain options may not be used depending on the settings used to generate the patch."
   onSubmit={savePlayerOptions}
   submitButtonLabel="Continue"
   title="Player Options"

--- a/src/renderer/components/settingsInputViews/SettingsButtonView.svelte
+++ b/src/renderer/components/settingsInputViews/SettingsButtonView.svelte
@@ -1,0 +1,23 @@
+<Button
+  style="text"
+  onClick={onClick}
+  title={viewModel.name}
+/>
+
+<script lang="ts">
+  import Button from "@components/buttons/Button.svelte"
+  import { handleButton } from "@components/PlayerOptionsView.svelte"
+  import type { ButtonViewModel } from "@shared/types/viewModels"
+  
+  type Props = {
+    viewModel: ButtonViewModel
+  }
+  
+  const {
+    viewModel = $bindable(),
+  }: Props = $props()
+  
+  const onClick = () => {
+    handleButton(viewModel.id)
+  }
+</script>

--- a/src/renderer/components/settingsInputViews/SettingsInputView.svelte
+++ b/src/renderer/components/settingsInputViews/SettingsInputView.svelte
@@ -20,6 +20,8 @@
   <ToggleView bind:viewModel={viewModel}/>
 {:else if viewModel.type === "INPUT_GROUP_LIST"}
   <InputGroupListView bind:viewModel={viewModel}/>
+{:else if viewModel.type === "BUTTON"}
+  <SettingsButtonView bind:viewModel={viewModel}/>
 {:else}
   <Never neverValue={viewModel}/>
 {/if}
@@ -32,6 +34,7 @@
   import IntegerInputView from "@components/settingsInputViews/IntegerInputView.svelte"
   import IntegerRangeInputView from "@components/settingsInputViews/IntegerRangeInputView.svelte"
   import MultilineTextInputView from "@components/settingsInputViews/MultilineTextInputView.svelte"
+  import SettingsButtonView from "@components/settingsInputViews/SettingsButtonView.svelte"
   import SimpleMultiSelectorView from "@components/settingsInputViews/SimpleMultiSelectorView.svelte"
   import SingleSelectorView from "@components/settingsInputViews/SingleSelectorView.svelte"
   import TextInputView from "@components/settingsInputViews/TextInputView.svelte"

--- a/src/shared/appData/applySettingsToViewModel.ts
+++ b/src/shared/appData/applySettingsToViewModel.ts
@@ -77,6 +77,10 @@ const applySettingsToInputViewModel = (settings: any, viewModel: InputViewModel,
     applySettingsToInputGroupListViewModel(settings, viewModel, path, warnings)
     break
   }
+  case "BUTTON": {
+    // Do nothing
+    break
+  }
   default: {
     const unhandledCase: never = viewModel
     throw new Error(`Unhandled case: ${unhandledCase}`)

--- a/src/shared/appData/applySettingsToViewModel.ts
+++ b/src/shared/appData/applySettingsToViewModel.ts
@@ -221,15 +221,19 @@ const applySettingsToToggleViewModel = (settings: any, viewModel: ToggleViewMode
   
   if (isBoolean(value)) {
     viewModel.isOn = value
-  } else if (!hasConfigurableSettings || !isObject(settings)) {
-    warnings.push(invalidValueWarning(path, expectedSettingsType, value))
-  } else if (isNullish(settings.VALUE)) {
-    warnings.push(missingValueWarning(`${path}.VALUE`, "boolean"))
   } else {
-    warnings.push(invalidValueWarning(`${path}.VALUE`, "boolean", value))
+    if (!hasConfigurableSettings || !isObject(settings)) {
+      warnings.push(invalidValueWarning(path, expectedSettingsType, value))
+    } else if (isNullish(settings.VALUE)) {
+      warnings.push(missingValueWarning(`${path}.VALUE`, "boolean"))
+    } else {
+      warnings.push(invalidValueWarning(`${path}.VALUE`, "boolean", value))
+    }
+    
+    return
   }
   
-  if (isNullish(settings) || !value) {
+  if (isNullish(settings) || !value && !path.includes("CHANGE_NAMES")) { // We want to keep the player's list of custom names even when they disable the CHANGE_NAMES option
     return
   }
   
@@ -254,7 +258,7 @@ const applySettingsToToggleViewModel = (settings: any, viewModel: ToggleViewMode
       return subViewModel.id
     })
     
-    Object.keys(settings.SETTINGS).find((key) => {
+    Object.keys(settings.SETTINGS).forEach((key) => {
       if (!subViewModelIds.includes(key)) {
         warnings.push(unexpectedKeyWarning(`${path}.SETTINGS`, key))
       }
@@ -269,7 +273,7 @@ const applySettingsToToggleViewModel = (settings: any, viewModel: ToggleViewMode
 }
 
 const applySettingsToSingleSelectorViewModel = (settings: any, viewModel: SingleSelectorViewModel, path: string, warnings: string[]) => {
-  const hasConfigurableOptions = viewModel.options.find((option) => {
+  const hasConfigurableOptions = viewModel.options.some((option) => {
     return "viewModels" in option
   })
   
@@ -312,7 +316,7 @@ const applySettingsToSingleSelectorViewModel = (settings: any, viewModel: Single
   }
   
   if (isObject(settings.SETTINGS)) {
-    Object.keys(settings.SETTINGS).find((key) => {
+    Object.keys(settings.SETTINGS).forEach((key) => {
       if (!optionIds.includes(key)) {
         warnings.push(unexpectedKeyWarning(`${path}.SETTINGS`, key))
       }

--- a/src/shared/appData/buttonIds.ts
+++ b/src/shared/appData/buttonIds.ts
@@ -1,0 +1,6 @@
+export const buttonIds = [
+  "IMPORT_CUSTOM_NAMES",
+  "EXPORT_CUSTOM_NAMES",
+] as const
+
+export type ButtonId = typeof buttonIds[number]

--- a/src/shared/appData/defaultPlayerOptionsViewModel.ts
+++ b/src/shared/appData/defaultPlayerOptionsViewModel.ts
@@ -239,44 +239,53 @@ const frameTypeOption = () => {
 
 const trainerNamesOption = () => {
   return createConfigurableToggleViewModel({
-    id: "CHANGE_TRAINER_NAMES" as const,
-    name: "Change Trainer Names",
-    description: "Changes the names and class names of the trainers that can be fought throughout the game.\n"
-      + "Note: The combined character count of a trainer's name and class name can never exceed 17 (16 for certain trainers).",
+    id: "CHANGE_NAMES" as const,
+    name: "Change Trainer Names and Pokémon Nicknames",
+    description: "Changes the names and class names of the trainers that can be fought throughout the game, as well as the nicknames of gift/trade Pokémon.",
     viewModels: [
       createSingleSelectorViewModel({
         id: "METHOD" as const,
-        selectedOptionId: "SHUFFLED",
+        selectedOptionId: "SHUFFLED_TRAINERS",
         options: [
           createSimpleSelectorOption({
-            id: "SHUFFLED" as const,
-            name: "Shuffled",
-            description: "Class names are shuffled amongst each other and trainer names are shuffled amongst each other (the names of trainers in the vanilla 'TWINS' trainer class are only shuffled amongst each other).",
+            id: "SHUFFLED_TRAINERS" as const,
+            name: "Shuffled Trainers",
+            description: "Class names are shuffled amongst each other and trainer names are shuffled amongst each other (the names of trainers in the vanilla 'TWINS' trainer class are only shuffled amongst each other).\n"
+             + "Pokémon Nicknames are unaffected.",
           }),
           createConfigurableSelectorOption({
             id: "CUSTOM_LIST" as const,
             name: "Custom List",
-            description: "Switches each trainer name for a random one from the supplied list.\n"
-              + "Each name in the lists should be on its own line.\n"
-              + "Class names should be no longer than 13 'in-game characters' or they will be truncated. "
-              + "The list of class names must also contain at least 1 name that is no larger than 7 'character tokens' long. "
-              + "If the list of class names is empty, they won't be changed. "
-              + "(For best results it is recommended to have a variety of class names ranging from 4-13 characters).\n"
-              + "Each trainer name should be no longer than 10 'in-game characters' or they will be truncated. "
-              + "(The lengths of trainer's names may also be limited by the length of their assigned class name).\n"
-              + "There is a separate list for the names of trainers in the 'TWINS' trainer class since thematically they should be 2 separate names, but are treated as only 1 name in the game.",
+            description: "Switches each trainer class and name and Pokémon nickname for a random one from the corresponding list. "
+              + "If any of lists are empty, those names won't be changed.\n"
+              + "Each name in the lists should be on its own line. "
+              + "Class names should be no longer than 13 'in-game characters'. "
+              + "Trainer names should be no longer than 10 'in-game characters'. "
+              + "Pokémon nicknames should be no longer than 10 'in-game characters' and no longer than 10 'character tokens' with at least 1 name that is no longer than 5 'character tokens'.\n"
+              + "If names are too long, they will be truncated. "
+              + "Also, the combined character count of a trainer's name and class name can never exceed 17 (16 for certain trainers) - "
+              + "names may also get truncated if it is not possible to satisfy this length restriction for all trainers. "
+              + "For best results, it is recommended to have a variety of names ranging from 4 characters long to the max length in each list.",
             viewModels: [
               createMultilineTextInputViewModel({
                 id: "ClASS_NAMES" as const,
                 name: "Class Names",
               }),
               createMultilineTextInputViewModel({
-                id: "TRAINER_NAMES" as const,
-                name: "Single Trainer Names",
+                id: "TWINS_CLASS_NAMES" as const,
+                name: "Twins Class Names",
               }),
               createMultilineTextInputViewModel({
-                id: "TWIN_NAMES" as const,
-                name: "Twin Trainer Names",
+                id: "TRAINER_NAMES" as const,
+                name: "Trainer Names",
+              }),
+              createMultilineTextInputViewModel({
+                id: "TWINS_TRAINER_NAMES" as const,
+                name: "Twins Trainer Names",
+              }),
+              createMultilineTextInputViewModel({
+                id: "POKEMON_NICKNAMES" as const,
+                name: "Pokémon Nicknames",
               }),
             ] as const,
           }),

--- a/src/shared/appData/defaultPlayerOptionsViewModel.ts
+++ b/src/shared/appData/defaultPlayerOptionsViewModel.ts
@@ -1,6 +1,7 @@
+import { nameLists } from "@shared/appData/nameListIds"
 import { playerSpriteMap } from "@shared/gameData/playerSprite"
 import { playerSpriteIds } from "@shared/types/gameDataIds/playerSprites"
-import { createConfigurableSelectorOption, createConfigurableToggleViewModel, createIntegerInputViewModel, createMultilineTextInputViewModel, createSimpleSelectorOption, createSimpleToggleViewModel, createSingleSelectorViewModel, createTextInputViewModel } from "@shared/types/viewModels"
+import { createButtonViewModel, createConfigurableSelectorOption, createConfigurableToggleViewModel, createIntegerInputViewModel, createMultilineTextInputViewModel, createSimpleSelectorOption, createSimpleToggleViewModel, createSingleSelectorViewModel, createTextInputViewModel } from "@shared/types/viewModels"
 
 export const defaultPlayerOptionsViewModel = () => {
   return {
@@ -267,25 +268,19 @@ const trainerNamesOption = () => {
               + "names may also get truncated if it is not possible to satisfy this length restriction for all trainers. "
               + "For best results, it is recommended to have a variety of names ranging from 4 characters long to the max length in each list.",
             viewModels: [
-              createMultilineTextInputViewModel({
-                id: "ClASS_NAMES" as const,
-                name: "Class Names",
+              createButtonViewModel({
+                id: "IMPORT_CUSTOM_NAMES",
+                name: "Import Custom Names",
               }),
-              createMultilineTextInputViewModel({
-                id: "TWINS_CLASS_NAMES" as const,
-                name: "Twins Class Names",
+              createButtonViewModel({
+                id: "EXPORT_CUSTOM_NAMES",
+                name: "Export Custom Names",
               }),
-              createMultilineTextInputViewModel({
-                id: "TRAINER_NAMES" as const,
-                name: "Trainer Names",
-              }),
-              createMultilineTextInputViewModel({
-                id: "TWINS_TRAINER_NAMES" as const,
-                name: "Twins Trainer Names",
-              }),
-              createMultilineTextInputViewModel({
-                id: "POKEMON_NICKNAMES" as const,
-                name: "Pokémon Nicknames",
+              ...nameLists.map((listInfo) => {
+                return createMultilineTextInputViewModel({
+                  id: listInfo.id,
+                  name: listInfo.name,
+                })
               }),
             ] as const,
           }),

--- a/src/shared/appData/nameListIds.ts
+++ b/src/shared/appData/nameListIds.ts
@@ -1,0 +1,44 @@
+  
+export const nameListIds = [
+  "CLASS_NAMES",
+  "TWINS_CLASS_NAMES",
+  "TRAINER_NAMES",
+  "TWINS_TRAINER_NAMES",
+  "POKEMON_NICKNAMES",
+] as const
+
+export type NameListId = typeof nameListIds[number]
+
+export type NameListInfo = {
+  id: NameListId
+  name: string
+  rncnSortOrder: number
+}
+
+export const nameLists: NameListInfo[] = [
+  {
+    id: "CLASS_NAMES",
+    name: "Class Names",
+    rncnSortOrder: 1,
+  },
+  {
+    id: "TWINS_CLASS_NAMES",
+    name: "Twins Class Names",
+    rncnSortOrder: 3,
+  },
+  {
+    id: "TRAINER_NAMES",
+    name: "Trainer Names",
+    rncnSortOrder: 0,
+  },
+  {
+    id: "TWINS_TRAINER_NAMES",
+    name: "Twins Trainer Names",
+    rncnSortOrder: 2,
+  },
+  {
+    id: "POKEMON_NICKNAMES",
+    name: "Pokémon Nicknames",
+    rncnSortOrder: 4,
+  },
+]

--- a/src/shared/appData/settingsFromViewModel.ts
+++ b/src/shared/appData/settingsFromViewModel.ts
@@ -1,4 +1,5 @@
 import type {
+  ButtonViewModel,
   ConfigurableMultiSelectorViewModel,
   ConfigurableSelectorOption,
   GroupMultiSelectorViewModel,
@@ -189,6 +190,7 @@ type SettingsFromInputViewModel<ViewModelType extends InputViewModel> =
   : ViewModelType extends GroupMultiSelectorViewModel ? SettingsFromGroupMultiSelectorViewModel<ViewModelType>
   : ViewModelType extends ToggleViewModel ? SettingsFromToggleViewModel<ViewModelType>
   : ViewModelType extends InputGroupListViewModel ? SettingsFromInputGroupListViewModel<ViewModelType>
+  : ViewModelType extends ButtonViewModel ? undefined
   : never
 const settingsFromInputViewModel = <ViewModelType extends InputViewModel>(viewModel: ViewModelType): SettingsFromInputViewModel<ViewModelType> => {
   switch (viewModel.type) {
@@ -224,6 +226,9 @@ const settingsFromInputViewModel = <ViewModelType extends InputViewModel>(viewMo
   }
   case "INPUT_GROUP_LIST": {
     return settingsFromInputGroupListViewModel(viewModel) as SettingsFromInputViewModel<ViewModelType>
+  }
+  case "BUTTON": {
+    return undefined as SettingsFromInputViewModel<ViewModelType>
   }
   default: {
     const unhandledCase: never = viewModel

--- a/src/shared/types/gameData/gameData.ts
+++ b/src/shared/types/gameData/gameData.ts
@@ -65,4 +65,6 @@ export type GameData = {
 export type PlayerSpecificGameData = {
   trainerClasses: IdMap<TrainerClassId, TrainerClass>
   trainers: Trainer[]
+  trades: IdMap<TradeId, Trade>
+  kenyaNickname: string
 }

--- a/src/shared/types/ipc/mainAPIInterface.ts
+++ b/src/shared/types/ipc/mainAPIInterface.ts
@@ -1,3 +1,4 @@
+import type { NameListId } from "@shared/appData/nameListIds"
 import type { PlayerOptions, Settings } from "@shared/appData/settingsFromViewModel"
 
 export interface MainAPIInterface {
@@ -34,6 +35,10 @@ export interface MainAPIInterface {
   ): Promise<VoidAPIResponse>
   
   exportSettings(settings: Settings): Promise<VoidAPIResponse>
+  
+  importCustomNames(): Promise<APIResponse<Partial<Record<NameListId, string>>>>
+  
+  exportCustomNames(lists: Partial<Record<NameListId, string>>): Promise<VoidAPIResponse>
   
   processInput(params: ProcessInputRequestParams): Promise<void>
   

--- a/src/shared/types/viewModels.ts
+++ b/src/shared/types/viewModels.ts
@@ -1,3 +1,4 @@
+import type { ButtonId } from "@shared/appData/buttonIds"
 import type { defaultPlayerOptionsViewModel } from "@shared/appData/defaultPlayerOptionsViewModel"
 import type { defaultSettingsViewModel } from "@shared/appData/defaultSettingsViewModel"
 
@@ -209,7 +210,7 @@ export const createConfigurableToggleViewModel = <IdType extends string, ViewMod
   }
 }
 
-// Stuff Selector
+// Input Group List
 
 export type InputGroupListViewModel = ReturnType<typeof createInputGroupListViewModel>
 export const createInputGroupListViewModel = <IdType extends string, ViewModelsType extends InputViewModelArray>(params: {
@@ -223,6 +224,19 @@ export const createInputGroupListViewModel = <IdType extends string, ViewModelsT
   return {
     ...params,
     type: "INPUT_GROUP_LIST" as const,
+  }
+}
+
+// Button
+
+export type ButtonViewModel = ReturnType<typeof createButtonViewModel>
+export const createButtonViewModel = (params: {
+  id: ButtonId
+  name: string
+}) => {
+  return {
+    ...params,
+    type: "BUTTON" as const,
   }
 }
 
@@ -240,12 +254,13 @@ export type InputViewModel =
   | GroupMultiSelectorViewModel
   | ToggleViewModel
   | InputGroupListViewModel
+  | ButtonViewModel
 type InputViewModelArray = InputViewModel[] | [] // Workaround to suppress circular type reference error
 
 // Tab View Model
 
 export type TabViewModel = ReturnType<typeof createTabViewModel>
-export const createTabViewModel = <ViewModelType extends InputViewModel>(params: {
+export const createTabViewModel = <ViewModelType extends ToggleViewModel | SimpleMultiSelectorViewModel>(params: {
   id: string
   name: string
   viewModels: ViewModelType[]

--- a/src/shared/utils/textConverters.ts
+++ b/src/shared/utils/textConverters.ts
@@ -1,3 +1,5 @@
+import { isNotNullish } from "@shared/utils/commonUtils"
+
 const characterMapFrom = (characters: string, startingValue: number) => {
   return characters.split("").reduce((map, character, index) => {
     map[character] = startingValue + index
@@ -90,7 +92,7 @@ export const truncateToInGameStringLength = (string: string, length: number) => 
   let result = string
   
   while (inGameStringLength(result) > length) {
-    if ([...result.matchAll(/<POKé>$|<PKMN>$/g)][0]) {
+    if (isNotNullish([...result.matchAll(/<POKé>$|<PKMN>$/g)][0])) {
       result = result.substring(0, result.length - 6)
     } else {
       result = result.substring(0, result.length - 1)

--- a/src/worker/gameDataProcessors/pokemonNicknames.ts
+++ b/src/worker/gameDataProcessors/pokemonNicknames.ts
@@ -1,0 +1,56 @@
+import type { PlayerOptions } from "@shared/appData/settingsFromViewModel"
+import type { PlayerSpecificGameData } from "@shared/types/gameData/gameData"
+import { bytesFromTextData, stringFrom, truncateToInGameStringLength } from "@shared/utils/textConverters"
+import type { Random } from "@worker/random"
+
+export const updatePokemonNicknames = (
+  playerOptions: PlayerOptions,
+  gameData: PlayerSpecificGameData,
+  random: Random,
+) => {
+  if (!playerOptions.CHANGE_NAMES.VALUE) {
+    return
+  }
+  
+  const method = playerOptions.CHANGE_NAMES.SETTINGS.METHOD
+  
+  if (method.VALUE !== "CUSTOM_LIST") {
+    return
+  }
+  
+  const allNicknames = method.SETTINGS.CUSTOM_LIST.POKEMON_NICKNAMES?.split("\n").map((name) => {
+    return truncateToInGameStringLength(name, 10)
+  }).filter((name) => {
+    return name.length > 0
+  }) ?? []
+  
+  let availableNicknames: string[] = []
+  Object.values(gameData.trades).forEach((trade) => {
+    if (availableNicknames.length === 0) {
+      availableNicknames = allNicknames.map((name) => { return name })
+    }
+    
+    trade.nickname = random.element({
+      array: availableNicknames,
+      remove: true,
+    })
+  })
+  
+  let kenyaNameOptions = availableNicknames.filter((name) => {
+    return bytesFromTextData(name).length <= 5
+  })
+  
+  if (kenyaNameOptions.length === 0) {
+    kenyaNameOptions = allNicknames.filter((name) => {
+      return bytesFromTextData(name).length <= 5
+    })
+  }
+  
+  if (kenyaNameOptions.length === 0) {
+    kenyaNameOptions = (availableNicknames.length !== 0 ? availableNicknames : allNicknames).map((name) => {
+      return stringFrom(bytesFromTextData(name).slice(0, 5))
+    })
+  }
+  
+  gameData.kenyaNickname = random.element({ array: kenyaNameOptions })
+}

--- a/src/worker/gameDataProcessors/trainerNames.ts
+++ b/src/worker/gameDataProcessors/trainerNames.ts
@@ -87,7 +87,7 @@ export const updateTrainerNames = (
     case "CUSTOM_LIST": {
       // Randomize class names
       
-      const allAvailableClassNames = method.SETTINGS.CUSTOM_LIST.ClASS_NAMES?.split("\n").map((name) => {
+      const allAvailableClassNames = method.SETTINGS.CUSTOM_LIST.CLASS_NAMES?.split("\n").map((name) => {
         return truncateToInGameStringLength(name, 13)
       }).filter((name) => {
         return name.length > 0

--- a/src/worker/gameDataProcessors/trainerNames.ts
+++ b/src/worker/gameDataProcessors/trainerNames.ts
@@ -1,6 +1,7 @@
 import type { PlayerOptions } from "@shared/appData/settingsFromViewModel"
 import type { PlayerSpecificGameData } from "@shared/types/gameData/gameData"
 import type { Trainer } from "@shared/types/gameData/trainer"
+import { isNotNullish } from "@shared/utils"
 import { bytesFromTextData, inGameStringLength, truncateToInGameStringLength } from "@shared/utils/textConverters"
 import type { Random } from "@worker/random"
 
@@ -9,19 +10,23 @@ export const updateTrainerNames = (
   gameData: PlayerSpecificGameData,
   random: Random,
 ) => {
-  if (playerOptions.CHANGE_TRAINER_NAMES.VALUE) {
-    const method = playerOptions.CHANGE_TRAINER_NAMES.SETTINGS.METHOD
+  if (playerOptions.CHANGE_NAMES.VALUE) {
+    const method = playerOptions.CHANGE_NAMES.SETTINGS.METHOD
     const trainerClasses = Object.values(gameData.trainerClasses)
     
     switch (method.VALUE) {
-    case "SHUFFLED": {
+    case "SHUFFLED_TRAINERS": {
       // Shuffle class names
       
-      const availableClassNames = trainerClasses.map((trainerClass) => {
+      const availableClassNames = trainerClasses.filter((trainerClasse) => {
+        return trainerClasse.id !== "TWINS"
+      }).map((trainerClass) => {
         return trainerClass.name
       })
       
-      trainerClasses.forEach((trainerClass) => {
+      trainerClasses.filter((trainerClasse) => {
+        return trainerClasse.id !== "TWINS"
+      }).forEach((trainerClass) => {
         trainerClass.name = random.element({
           array: availableClassNames,
           remove: true,
@@ -82,40 +87,70 @@ export const updateTrainerNames = (
     case "CUSTOM_LIST": {
       // Randomize class names
       
-      const availableClassNames = method.SETTINGS.CUSTOM_LIST.ClASS_NAMES?.split("\n").map((name) => {
+      const allAvailableClassNames = method.SETTINGS.CUSTOM_LIST.ClASS_NAMES?.split("\n").map((name) => {
         return truncateToInGameStringLength(name, 13)
       }).filter((name) => {
         return name.length > 0
       }) ?? []
       
-      if (availableClassNames.length > 1) {
-        availableClassNames.sort((a, b) => {
+      if (allAvailableClassNames.length > 0) {
+        allAvailableClassNames.sort((a, b) => {
           return bytesFromTextData(a).length - bytesFromTextData(b).length
         })
       
-        if (bytesFromTextData(availableClassNames[0]).length > 7) {
-          availableClassNames.unshift("TRAINER")
+        if (bytesFromTextData(allAvailableClassNames[0]).length > 7) {
+          allAvailableClassNames.unshift("TRAINER")
         }
       
         let availableBytes = 502
-      
-        let classNameIndex = 0
+        
         const trainerClassIndices = trainerClasses.map((_, index) => { return index })
+        let availableClassNameIndices = allAvailableClassNames.map((_, index) => { return index })
+        
         while (trainerClassIndices.length > 0) {
+          const lengthOfShortestAvailableName = bytesFromTextData(allAvailableClassNames[0]).length
+          const classesRemainingAfterNextSelection = trainerClassIndices.length - 1
+          const minBytesStillRequiredAfterNextSelection = lengthOfShortestAvailableName * classesRemainingAfterNextSelection
+          const maxLengthOfNextSelection = availableBytes - minBytesStillRequiredAfterNextSelection
+          const indexOfLongestAvailableName = availableClassNameIndices[availableClassNameIndices.length - 1]
+        
+          if (availableClassNameIndices.length === 0 || maxLengthOfNextSelection < bytesFromTextData(allAvailableClassNames[indexOfLongestAvailableName]).length) {
+            availableClassNameIndices = allAvailableClassNames.map((_, index) => {
+              return index
+            }).filter((index) => {
+              return bytesFromTextData(allAvailableClassNames[index]).length <= maxLengthOfNextSelection
+            })
+          }
+          
           const trainerClassIndex = random.element({
             array: trainerClassIndices,
             remove: true,
           })
-        
-          trainerClasses[trainerClassIndex].name = availableClassNames[classNameIndex]
-          availableBytes -= trainerClasses[trainerClassIndex].name.length
-        
-          classNameIndex++
-        
-          if (classNameIndex === availableClassNames.length || availableClassNames[0].length * (trainerClassIndices.length - 1) > availableBytes - availableClassNames[classNameIndex].length) {
-            classNameIndex = 0
+          
+          if (trainerClasses[trainerClassIndex].id === "TWINS") {
+            continue
           }
+          
+          const classNameIndex = random.element({
+            array: availableClassNameIndices,
+            remove: true,
+          })
+        
+          trainerClasses[trainerClassIndex].name = allAvailableClassNames[classNameIndex]
+          availableBytes -= trainerClasses[trainerClassIndex].name.length
         }
+      }
+      
+      // Randomize Twins Class Name
+      
+      const availableTwinsClassNames = method.SETTINGS.CUSTOM_LIST.TWINS_CLASS_NAMES?.split("\n").map((name) => {
+        return truncateToInGameStringLength(name, 13)
+      }).filter((name) => {
+        return name.length > 0
+      }) ?? []
+      
+      if (availableTwinsClassNames.length > 0) {
+        gameData.trainerClasses.TWINS.name = random.element({ array: availableTwinsClassNames })
       }
       
       // Randomize Trainer Names
@@ -126,7 +161,7 @@ export const updateTrainerNames = (
         return name.length > 0
       }) ?? []
       
-      const twinTrainerNames = method.SETTINGS.CUSTOM_LIST.TWIN_NAMES?.split("\n").map((name) => {
+      const twinsTrainerNames = method.SETTINGS.CUSTOM_LIST.TWINS_TRAINER_NAMES?.split("\n").map((name) => {
         return truncateToInGameStringLength(name, 10)
       }).filter((name) => {
         return name.length > 0
@@ -139,20 +174,31 @@ export const updateTrainerNames = (
       }).forEach((trainer) => {
         const className = gameData.trainerClasses[trainer.classId].name
         
-        if (changedNames[className + trainer.name]) {
+        if (
+          isNotNullish(changedNames[className + trainer.name])
+          && trainer.classId !== "ROCKET_GRUNT_M"
+          && trainer.classId !== "ROCKET_GRUNT_F"
+          && trainer.classId !== "ROCKET_EXECUTIVE_M"
+          && trainer.classId !== "ROCKET_EXECUTIVE_F"
+        ) {
           trainer.name = changedNames[className + trainer.name]
           return
         }
         
         const maxCombinedLength = trainer.isContestTrainer ?? false ? 16 : 17
-        const namesList = trainer.classId === "TWINS" ? twinTrainerNames : singleTrainerNames
-        const validNames = namesList.filter((name) => {
-          return inGameStringLength(className) + inGameStringLength(name) <= maxCombinedLength
-        })
+        const maxNameLength = maxCombinedLength - inGameStringLength(className)
+        const namesList = trainer.classId === "TWINS" ? twinsTrainerNames : singleTrainerNames
+        let newName = truncateToInGameStringLength(trainer.name, maxNameLength)
         
-        const newName = random.element({
-          array: validNames.length > 0 ? validNames : trainer.classId === "TWINS" ? ["T&T"] : ["BOB"],
-        })
+        if (namesList.length > 0) {
+          const validNames = namesList.filter((name) => {
+            return inGameStringLength(className) + inGameStringLength(name) <= maxCombinedLength
+          })
+        
+          newName = truncateToInGameStringLength(random.element({
+            array: validNames.length > 0 ? validNames : namesList,
+          }), maxNameLength)
+        }
         
         changedNames[className + trainer.name] = newName
         trainer.name = newName

--- a/src/worker/generator.ts
+++ b/src/worker/generator.ts
@@ -8,6 +8,7 @@ import { movesMap } from "@shared/gameData/moves"
 import { playerSpriteMap } from "@shared/gameData/playerSprite"
 import { pokemonMap } from "@shared/gameData/pokemon"
 import { starterLocationsMap } from "@shared/gameData/starterLocations"
+import { tradesMap } from "@shared/gameData/trades"
 import { trainerClassesMap } from "@shared/gameData/trainerClasses"
 import { trainerMovementBehavioursMap } from "@shared/gameData/trainerMovementBehaviours"
 import { trainers } from "@shared/gameData/trainers"
@@ -45,6 +46,7 @@ import { updateMoveTutorCost } from "@worker/gameDataProcessors/moveTutorCost"
 import { updateNumberOfBadgesForOak } from "@worker/gameDataProcessors/numberOfBadgesForOak"
 import { updateNumberOfMiltankBerries } from "@worker/gameDataProcessors/numberOfMiltankBerries"
 import { updatePokemonInfo } from "@worker/gameDataProcessors/pokemonInfo"
+import { updatePokemonNicknames } from "@worker/gameDataProcessors/pokemonNicknames"
 import { updatePrices } from "@worker/gameDataProcessors/prices"
 import { updateStarterItems, updateStarters } from "@worker/gameDataProcessors/starters"
 import { updateTeachableMoves } from "@worker/gameDataProcessors/teachableMoves"
@@ -135,9 +137,12 @@ export const applyPlayerOptions = (params: ApplyPlayerOptionsParams) => {
   const gameData = {
     trainerClasses: JSON.parse(JSON.stringify(trainerClassesMap)) as typeof trainerClassesMap,
     trainers: JSON.parse(JSON.stringify(trainers)) as typeof trainers,
+    trades: JSON.parse(JSON.stringify(tradesMap)) as typeof tradesMap,
+    kenyaNickname: "KENYA",
   }
   
   updateTrainerNames(playerOptions, gameData, random)
+  updatePokemonNicknames(playerOptions, gameData, random)
   
   const hunks = createPlayerOptionsPatches({
     settings: settings,
@@ -148,7 +153,7 @@ export const applyPlayerOptions = (params: ApplyPlayerOptionsParams) => {
   
   applyDataHunks(rom, hunks)
   
-  if (playerOptions.CHANGE_TRAINER_NAMES.VALUE && playerOptions.CHANGE_TRAINER_NAMES.SETTINGS.CREATE_LOG) {
+  if (playerOptions.CHANGE_NAMES.VALUE && playerOptions.CHANGE_NAMES.SETTINGS.CREATE_LOG) {
     return playerSpecificLog(gameData)
   } else {
     return undefined
@@ -2501,7 +2506,7 @@ const createPlayerOptionsPatches = (params: {
   
   // Trainer Names
   
-  if (playerOptions.CHANGE_TRAINER_NAMES.VALUE) {
+  if (playerOptions.CHANGE_NAMES.VALUE) {
     // Class names
     
     patchHunks.push({
@@ -2581,6 +2586,23 @@ const createPlayerOptionsPatches = (params: {
       },
     ])
   }
+  
+  // Pokémon Nicknames
+  
+  const firstTradeNicknameOffset = romOffsetFromBankAddress(63, 0x4E5A)
+  
+  patchHunks.push(...[
+    ...Object.values(gameData.trades).map((trade, index) => {
+      return {
+        offset: firstTradeNicknameOffset + 32 * index,
+        values: bytesFromTextData(trade.nickname.padEnd(11, "@")),
+      }
+    }),
+    {
+      offset: romOffsetFromBankAddress(26, 0x5DB9),
+      values: bytesFromTextData(gameData.kenyaNickname.padEnd(6, "@")),
+    },
+  ])
   
   return patchHunks
 }

--- a/src/worker/log.ts
+++ b/src/worker/log.ts
@@ -5,6 +5,7 @@ import { movesMap } from "@shared/gameData/moves"
 import { oddEggs } from "@shared/gameData/oddEggs"
 import { pokemonMap } from "@shared/gameData/pokemon"
 import { starterLocationsMap } from "@shared/gameData/starterLocations"
+import { tradesMap } from "@shared/gameData/trades"
 import { trainerClassesMap } from "@shared/gameData/trainerClasses"
 import { trainers } from "@shared/gameData/trainers"
 import { eventPokemonMap } from "@shared/types/gameData/eventPokemon"
@@ -20,6 +21,7 @@ import { isMoveId } from "@shared/types/gameDataIds/moves"
 import { isPokemonId, pokemonIds } from "@shared/types/gameDataIds/pokemon"
 import { starterLocationIds } from "@shared/types/gameDataIds/starterLocations"
 import { moveTutorIds } from "@shared/types/gameDataIds/teachableMoves"
+import { tradeIds } from "@shared/types/gameDataIds/trades"
 import { trainerClassIds } from "@shared/types/gameDataIds/trainerClasses"
 import { treeGroupIds } from "@shared/types/gameDataIds/treeGroups"
 import type { UnownSetId } from "@shared/types/gameDataIds/unownSets"
@@ -182,7 +184,7 @@ export const generatorLog = (params: {
               showTimeColumn ? encounter.type === "WATER" ? "ANY" : encounter.time : undefined,
               encounter.pokemonId,
               `Lv. ${encounter.level}`,
-              `${ratios[encounter.slot]}% ${encounter.type === "LAND" && encounter.isSwarm ? " (SWARM)" : ""}`,
+              `${ratios[encounter.slot]}% ${encounter.type === "LAND" && (encounter.isSwarm ?? false) ? " (SWARM)" : ""}`,
             ])
           }),
         }
@@ -687,7 +689,11 @@ export const generatorLog = (params: {
 }
 
 export const playerSpecificLog = (gameData: PlayerSpecificGameData) => {
-  return logTable({
+  const sections: string[] = []
+  
+  sections.push("----- TRAINER NAMES -----")
+  
+  sections.push(logTable({
     headers: [
       "ORIGINAL",
       "NEW",
@@ -713,7 +719,34 @@ export const playerSpecificLog = (gameData: PlayerSpecificGameData) => {
         }),
       },
     ],
-  })
+  }))
+  
+  sections.push("----- POKEMON NICKNAMES -----")
+  
+  sections.push(logTable({
+    headers: [
+      "ORIGINAL",
+      "NEW",
+    ],
+    sections: [
+      {
+        rows: [
+          ...tradeIds.map((tradeId) => {
+            return [
+              tradesMap[tradeId].nickname,
+              gameData.trades[tradeId].nickname,
+            ]
+          }),
+          [
+            "KENYA",
+            gameData.kenyaNickname,
+          ],
+        ],
+      },
+    ],
+  }))
+  
+  return sections.join("\n\n")
 }
 
 const logTable = (params: {


### PR DESCRIPTION
Fixes and improvements to how trainer names are randomized. Includes better options for twins, the ability to randomize trade/gift pokemon nicknames, the ability to import/export the custom name lists and improved saving the all the player options as they are changed.