### PR TITLE
Good damaging exceptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-crystal-randomizer",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-crystal-randomizer",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "devDependencies": {
         "@electron-forge/cli": "7.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-crystal-randomizer",
   "productName": "Pokemon Crystal Randomizer",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Generate and apply patches for Pokémon Crystal Version",
   "author": "David Bagwell",
   "license": "MIT",

--- a/src/resources/presets/BINGO_PLUS.yml
+++ b/src/resources/presets/BINGO_PLUS.yml
@@ -179,6 +179,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -194,6 +211,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/CLASSIC_CRAZY_FIR.yml
+++ b/src/resources/presets/CLASSIC_CRAZY_FIR.yml
@@ -173,6 +173,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:
@@ -191,6 +208,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -206,6 +240,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/CLASSIC_EXTREME_FIR.yml
+++ b/src/resources/presets/CLASSIC_EXTREME_FIR.yml
@@ -173,6 +173,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:
@@ -191,6 +208,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -206,6 +240,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/CLASSIC_EXTREME_KIR.yml
+++ b/src/resources/presets/CLASSIC_EXTREME_KIR.yml
@@ -173,6 +173,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:
@@ -191,6 +208,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -206,6 +240,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/CLASSIC_FIR.yml
+++ b/src/resources/presets/CLASSIC_FIR.yml
@@ -173,6 +173,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:
@@ -191,6 +208,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -206,6 +240,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/CLASSIC_KIR.yml
+++ b/src/resources/presets/CLASSIC_KIR.yml
@@ -173,6 +173,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:
@@ -191,6 +208,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -206,6 +240,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/CLASSIC_MAX.yml
+++ b/src/resources/presets/CLASSIC_MAX.yml
@@ -184,6 +184,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:
@@ -202,6 +219,23 @@ RANDOMIZE_TM_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN:
       - HEADBUTT
       - ROCK_SMASH
@@ -217,6 +251,23 @@ RANDOMIZE_MOVE_TUTOR_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     BAN: []
 RANDOMIZE_HM_COMPATIBILITY:
   VALUE: true

--- a/src/resources/presets/MAXIMUM_PLUS.yml
+++ b/src/resources/presets/MAXIMUM_PLUS.yml
@@ -190,6 +190,23 @@ RANDOMIZE_LEVEL_UP_MOVES:
       SETTINGS:
         PERCENTAGE: 25
         POWER: 50
+        INCLUDE:
+          - DOUBLE_KICK
+          - SPIKE_CANNON
+        EXCLUDE:
+          - MEGA_PUNCH
+          - RAZOR_WIND
+          - SLAM
+          - ROLLING_KICK
+          - TAKE_DOWN
+          - SUBMISSION
+          - BONE_CLUB
+          - CRABHAMMER
+          - OCTAZOOKA
+          - SELFDESTRUCT
+          - DREAM_EATER
+          - EXPLOSION
+          - FUTURE_SIGHT
     GUARANTEE_LEVEL_ONE_MOVES:
       VALUE: true
       SETTINGS:

--- a/src/shared/appData/defaultSettingsViewModel.ts
+++ b/src/shared/appData/defaultSettingsViewModel.ts
@@ -2322,6 +2322,28 @@ const createGoodDamagingMovesToggleViewModel = (distinguisher: string = "") => {
         max: 250,
         value: 50,
       }),
+      createSimpleMultiSelectorViewModel({
+        id: "INCLUDE" as const,
+        name: "Include",
+        description: "Moves that should count as 'Good Damaging Moves' even if their Power isn't high enough.",
+        options: moveIds.map((moveId) => {
+          return createSimpleSelectorOption({
+            id: moveId,
+            name: movesMap[moveId].name,
+          })
+        }),
+      }),
+      createSimpleMultiSelectorViewModel({
+        id: "EXCLUDE" as const,
+        name: "Exclude",
+        description: "Moves that should not count as 'Good Damaging Moves' even if their Power is high enough.",
+        options: moveIds.map((moveId) => {
+          return createSimpleSelectorOption({
+            id: moveId,
+            name: movesMap[moveId].name,
+          })
+        }),
+      }),
     ] as const,
   })
 }

--- a/src/worker/gameDataProcessors/levelUpMoves.ts
+++ b/src/worker/gameDataProcessors/levelUpMoves.ts
@@ -37,7 +37,8 @@ export const updateLevelUpMoves = (
       
     const matchesForcedGoodMovesConditions = (move: Move, index: number) => {
       if (indicesOfForcedGoodMoves.includes(index)) {
-        return move.power >= minPowerForForcedGoodMoves
+        return move.power >= minPowerForForcedGoodMoves && levelUpMovesSettings.GOOD_DAMAGING_MOVES.SETTINGS.EXCLUDE.includes(move.id)
+          || levelUpMovesSettings.GOOD_DAMAGING_MOVES.SETTINGS.INCLUDE.includes(move.id)
       } else {
         return true
       }

--- a/src/worker/gameDataProcessors/teachableMoves.ts
+++ b/src/worker/gameDataProcessors/teachableMoves.ts
@@ -34,7 +34,8 @@ export const updateTeachableMoves = (
       
     const matchesForcedGoodMovesConditions = (move: Move, index: number) => {
       if (indicesOfForcedGoodMoves.includes(index)) {
-        return move.power >= minPowerForForcedGoodMoves
+        return move.power >= minPowerForForcedGoodMoves && tmsSettings.GOOD_DAMAGING_MOVES.SETTINGS.EXCLUDE.includes(move.id)
+          || tmsSettings.GOOD_DAMAGING_MOVES.SETTINGS.INCLUDE.includes(move.id)
       } else {
         return true
       }
@@ -108,7 +109,8 @@ export const updateTeachableMoves = (
       
     const matchesForcedGoodMovesConditions = (move: Move, index: number) => {
       if (indicesOfForcedGoodMoves.includes(index)) {
-        return move.power >= minPowerForForcedGoodMoves
+        return move.power >= minPowerForForcedGoodMoves && moveTutorSettings.GOOD_DAMAGING_MOVES.SETTINGS.EXCLUDE.includes(move.id)
+          || moveTutorSettings.GOOD_DAMAGING_MOVES.SETTINGS.INCLUDE.includes(move.id)
       } else {
         return true
       }


### PR DESCRIPTION
Added "Include" and "Exclude" options to the "Good Damaging Moves" settings to allow exceptions for what counts as a good damaging move.

Also added a bunch of exceptions to all the presets so that the "good damaging moves" match the classic ones.