### PR TITLE
Fix bargain shop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-crystal-randomizer",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-crystal-randomizer",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "devDependencies": {
         "@electron-forge/cli": "7.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-crystal-randomizer",
   "productName": "Pokemon Crystal Randomizer",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Generate and apply patches for Pokémon Crystal Version",
   "author": "David Bagwell",
   "license": "MIT",

--- a/src/resources/patchSpecs/buyableSweetScent.yml
+++ b/src/resources/patchSpecs/buyableSweetScent.yml
@@ -20,10 +20,3 @@ changes:
     maxSize: 50
     freeUnused: true
   value: "03 @$clerkScript"
-- description: "Skip code checking number of marts."
-  locations:
-  - bank: 5
-    address: 0x5B32
-    maxSize: 10
-    freeUnused: true
-  value: "18 08"

--- a/src/resources/patchSpecs/marts.yml
+++ b/src/resources/patchSpecs/marts.yml
@@ -11,3 +11,14 @@ changes:
   - bank: 5
     address: 0x5B3D
   value: "@$martData"
+- description: "Skip code checking number of marts."
+  locations:
+  - bank: 5
+    address: 0x5B32
+    maxSize: 10
+    freeUnused: true
+  value: "18 08"
+freeSpaces:
+  - bank: 5
+    address: 0x60A9
+    size: 367

--- a/src/worker/generator.ts
+++ b/src/worker/generator.ts
@@ -1118,7 +1118,15 @@ const createPatches = (
     return hexStringFrom(bytesFromTextData(specialShopItemName(shopId, index).padEnd(12, " ") + `${specialShopItemInfo(shopId, index).price}`.padStart(5, " ")))
   }
   
-  const shouldApplyShopItemChanges = settings.SHUFFLE_ITEMS.SETTINGS.GROUPS.flat().includes("SHOPS") || settings.START_WITH_ITEMS.SETTINGS.REPLACE_EXISTING_ITEMS.VALUE
+  const shouldApplyShopItemChanges = settings.SHUFFLE_ITEMS.VALUE && settings.SHUFFLE_ITEMS.SETTINGS.GROUPS.flat().includes("SHOPS")
+    || settings.START_WITH_ITEMS.SETTINGS.REPLACE_EXISTING_ITEMS.VALUE
+  
+  if (shouldApplyShopItemChanges) {
+    romInfo.patchHunks.push({
+      offset: romOffsetFromBankAddress(31, 0x415D),
+      values: [martIds.length],
+    })
+  }
   
   if (shouldApplyShopItemChanges || settings.RANDOMIZE_BLUE_CARD_REWARD_COSTS.VALUE) {
     romInfo.patchHunks.push(...[


### PR DESCRIPTION
Fixed an issue where the bargain shop purchase flags were being shared with the initial cherrygrove mart which could sometimes cause issues when trying to buy key items from those shops.